### PR TITLE
feat: add central leanix renovate config preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,0 +1,6 @@
+{
+    "packageRules": {
+        "minimumReleaseAge": "3 days",
+        "internalChecksFilter": "strict"
+    }
+}

--- a/default.json
+++ b/default.json
@@ -1,6 +1,10 @@
 {
-    "packageRules": {
-        "minimumReleaseAge": "3 days",
-        "internalChecksFilter": "strict"
+  "extends": ["config:best-practices"],
+  "internalChecksFilter": "strict",
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
     }
+  ]
 }


### PR DESCRIPTION
**WHY**
Teams can extend their renovate config from this and will get central configuration updates automatically in the future.

**WHAT**
Create a renovate config preset to be used in any of our repositories like this:

```json
{
  "extends": ["github>leanix/.github"]
}
```