### PR TITLE
feat: pin all but peer dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,9 @@
 {
   "enabled": true,
-  "extends": ["config:best-practices"],
+  "extends": [
+    "config:best-practices",
+    ":pinAllExceptPeerDependencies"
+  ],
   "internalChecksFilter": "strict",
   "packageRules": [
     {


### PR DESCRIPTION
**WHY**
This preset might be used across LeanIX as it'll give us a single point to control renovate in situations like a supply chain attack.

**WHAT**
This preset pins all dependencies except for peer dependencies and mitigates supply chain attacks be adopting npm provided dependencies only if the release happened at least 3 days ago. It also checks of abandoned dependencies and reports those in the dependency dashboard. For more details on renovate provided presets see the [documentation](https://docs.renovatebot.com/presets-config/#configbest-practices)