### PR TITLE
chore(renovate-preset): rebase on conflict DEVX-659

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
     ":pinAllExceptPeerDependencies",
     "github>leanix/.github//renovate-presets/security.json5"
   ],
+  "rebaseWhen": "conflicted",
   "internalChecksFilter": "strict",
   "minimumReleaseAge": "5 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional",


### PR DESCRIPTION
**WHY** Numerous renovate PRs remain unmerged for days, weeks or even months. Renovate would rebase these branches whenever it detects they are behind the default branch causing another CI run. This causes high load on our CI infrastructure without much benefit. Many repositories do not require a linear history yet and thus don't need to be keep up-to-date. There is a risk to this since incompatibilities might go unnoticed, but this is true for any change in such a context. Midterm DevX team butterfly plans to require linear history for all repositories which requires a merge queue to work efficiently. The change has been tested in some repositories including product-analytics-pipeline where it reduce the shared of CI runs caused by renovate from 67% to 9%.

**WHAT** Renovate preset adjusted so renovate would rebase only if it detects merge conflicts between default and feature branch.