### PR TITLE
feat(renovate-preset): assign codeowners as reviewers DEVX-661

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,7 @@
   "internalChecksFilter": "strict",
   "minimumReleaseAge": "5 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "reviewersFromCodeOwners": true,
   "packageRules": [
     {
       "matchPackageNames": ["io.kubernetes:client-java"],


### PR DESCRIPTION
**WHY** Improve visibility of renovate PRs to teams owning the repository.

**WHAT** Renovate assign CODEOWNERS as reviewers for each of its PRs.