### PR TITLE
feat: add lock file maintenance to automerge preset

### DIFF
--- a/renovate-presets/README.md
+++ b/renovate-presets/README.md
@@ -15,6 +15,7 @@ This directory contains shareable Renovate configuration presets that can be use
 
 **Features**:
 - Automatically merges minor, patch, and digest updates
+- Automatically merges lock file maintenance PRs
 - Operates on Berlin timezone (Europe/Berlin)
 - PR creation window: Monday-Friday, 9:00-13:00
 - Uses pull request automerge strategy

--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -12,7 +12,8 @@ Prerequisites for this preset:
             "matchUpdateTypes": [
                 "minor",
                 "patch",
-                "digest"
+                "digest",
+                "lockFileMaintenance"
             ],
             // Create PRs only during working hours
             // This controls the update window for scenarios using platform automerge
@@ -37,17 +38,5 @@ Prerequisites for this preset:
             "internalChecksFilter": "strict",
             "rebaseWhen": "conflicted"
         }
-    ],
-    "lockFileMaintenance": {
-        "schedule": [
-            "* 9-13 * * 1-5"
-        ],
-        "automerge": true,
-        "automergeType": "pr",
-        "automergeStrategy": "auto",
-        "platformAutomerge": true,
-        "prCreation": "not-pending",
-        "internalChecksFilter": "strict",
-        "rebaseWhen": "conflicted"
-    }
+    ]
 }

--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -37,5 +37,17 @@ Prerequisites for this preset:
             "internalChecksFilter": "strict",
             "rebaseWhen": "conflicted"
         }
-    ]
+    ],
+    "lockFileMaintenance": {
+        "schedule": [
+            "* 9-13 * * 1-5"
+        ],
+        "automerge": true,
+        "automergeType": "pr",
+        "automergeStrategy": "auto",
+        "platformAutomerge": true,
+        "prCreation": "not-pending",
+        "internalChecksFilter": "strict",
+        "rebaseWhen": "conflicted"
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `lockFileMaintenance` automerge configuration to the shared `automerge.json5` preset
- Lock file maintenance PRs will now be auto-merged during business hours (Mon-Fri 9-13 CET), same as minor/patch/digest updates
- Updates README to document the new behavior

## Motivation
Lock file maintenance PRs are low-risk (they only update the lock file without changing version ranges) but were not covered by the `matchUpdateTypes` package rule since `lockFileMaintenance` is a separate Renovate config key, not a standard update type.

## Test plan
- [ ] Verify Renovate validates the updated preset without errors
- [ ] Confirm lock file maintenance PRs get auto-merged on repos using this preset