### PR TITLE
Feature/DEVX 672 control renovate automerge schedule in automerge json 5 preset

### DIFF
--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -17,6 +17,12 @@ Prerequisites for this preset:
             "schedule": [
                 "* 9-13 * * 1-5"
             ],
+            /* Maintain backwards compatibility for repositories
+            that do not require a merge queue and thus control
+            automerges in renovate still */
+            "automergeSchedule": [
+                "* 9-13 * * 1-5"
+            ],
             "automerge": true,
             "automergeType": "pr",
             "automergeStrategy": "auto",

--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -14,6 +14,9 @@ Prerequisites for this preset:
                 "patch",
                 "digest"
             ],
+            // Create PRs only during working hours
+            // This controls the update window for scenarios using platform automerge
+            // when renovate loses control over the merge schedule
             "schedule": [
                 "* 9-13 * * 1-5"
             ],
@@ -26,7 +29,10 @@ Prerequisites for this preset:
             "automerge": true,
             "automergeType": "pr",
             "automergeStrategy": "auto",
+            // Enable Github automerge (renovate loses control over the merge schedule)
             "platformAutomerge": true,
+            // Create PRs only if the stability days check has passed
+            // This prevents premature PR merges
             "prCreation": "not-pending",
             "internalChecksFilter": "strict",
             "rebaseWhen": "conflicted"


### PR DESCRIPTION
# Add Scheduling Comments and `automergeSchedule` to Renovate Automerge Preset

### Refactor

♻️ Enhanced the `automerge.json5` Renovate preset with improved inline documentation and an explicit `automergeSchedule` configuration for backwards compatibility.

### Changes

* `renovate-presets/automerge.json5`:
  - Added explanatory comments clarifying the purpose of the `schedule` field — it controls PR creation windows for both platform automerge and merge queue scenarios where Renovate loses control over the merge schedule.
  - Added `automergeSchedule` (set to `* 9-13 * * 1-5`) with a backwards-compatibility note for repositories that do **not** use a merge queue and still rely on Renovate to control automerge timing.
  - Added a comment clarifying that `platformAutomerge: true` causes Renovate to lose control over the merge schedule.
  - Added comments explaining that `prCreation: not-pending` prevents premature PR merges by waiting for stability days checks to pass.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.23`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `f4bbcc67-57b9-4239-9573-948fc200b8fe`
- Event Trigger: `pull_request.opened`
</details>
