### PR TITLE
DEVX-665: chore: configure renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>leanix/.github"
+    "github>leanix/.github",
+    "github>leanix/.github//renovate-presets/automerge.json5"
   ]
 }


### PR DESCRIPTION
This PR was created by `setup-renovate-automerge.sh`.

## Changes
- Adds `github>leanix/.github` to `extends` (if not present)
- Adds `github>leanix/.github//renovate-presets/automerge.json5` to `extends` (if not present)
- Removes `github>leanix/.github//renovate-presets/branch-merge` from `extends` (if present)

## Why
The `branch-merge` preset is deprecated and lacks crucial features like merge queue support. The behavior remains unchanged, except PRs are now created and automerged.
