### PR TITLE
Temporarily disable renovate completely for sapphire week

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,5 +1,5 @@
 {
-  "enabled": true,
+  "enabled": false,
   "extends": [
     "config:best-practices",
     ":pinAllExceptPeerDependencies",

--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -6,37 +6,28 @@ Prerequisites for this preset:
  - CI workflow trigger on `merge_group:` event or on push to temporary merge queue branches *(Only if Merge Queue enabled)*
 */
 {
-    "timezone": "Europe/Berlin",
-    "packageRules": [
-        {
-            "matchUpdateTypes": [
-                "minor",
-                "patch",
-                "digest",
-                "lockFileMaintenance"
-            ],
-            // Create PRs only during working hours
-            // This controls the update window for scenarios using platform automerge
-            // when renovate loses control over the merge schedule
-            "schedule": [
-                "* 9-13 * * 1-5"
-            ],
-            /* Maintain backwards compatibility for repositories
+  timezone: "Europe/Berlin",
+  packageRules: [
+    {
+      matchUpdateTypes: ["minor", "patch", "digest", "lockFileMaintenance"],
+      // Create PRs only during working hours
+      // This controls the update window for scenarios using platform automerge
+      // when renovate loses control over the merge schedule
+      schedule: ["* 9-13 * * 1-5"],
+      /* Maintain backwards compatibility for repositories
             that do not require a merge queue and thus control
             automerges in renovate still */
-            "automergeSchedule": [
-                "* 9-13 * * 1-5"
-            ],
-            "automerge": true,
-            "automergeType": "pr",
-            "automergeStrategy": "auto",
-            // Enable Github automerge (renovate loses control over the merge schedule)
-            "platformAutomerge": true,
-            // Create PRs only if the stability days check has passed
-            // This prevents premature PR merges
-            "prCreation": "not-pending",
-            "internalChecksFilter": "strict",
-            "rebaseWhen": "conflicted"
-        }
-    ]
+      automergeSchedule: ["* 9-13 * * 1-5"],
+      automerge: true,
+      automergeType: "pr",
+      automergeStrategy: "auto",
+      // Enable Github automerge (renovate loses control over the merge schedule)
+      platformAutomerge: true,
+      // Create PRs only if the stability days check has passed
+      // This prevents premature PR merges
+      prCreation: "not-pending",
+      internalChecksFilter: "strict",
+      rebaseWhen: "conflicted",
+    },
+  ],
 }

--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -6,37 +6,28 @@ Prerequisites for this preset:
  - CI workflow trigger on `merge_group:` event or on push to temporary merge queue branches *(Only if Merge Queue enabled)*
 */
 {
-    "timezone": "Europe/Berlin",
-    "packageRules": [
-        {
-            "matchUpdateTypes": [
-                "minor",
-                "patch",
-                "digest",
-                "lockFileMaintenance"
-            ],
-            // Create PRs only during working hours
-            // This controls the update window for scenarios using platform automerge
-            // when renovate loses control over the merge schedule
-            "schedule": [
-                "* 9-13 * * 1-5"
-            ],
-            /* Maintain backwards compatibility for repositories
+  timezone: "Europe/Berlin",
+  packageRules: [
+    {
+      matchUpdateTypes: ["minor", "patch", "digest", "lockFileMaintenance"],
+      // Create PRs only during working hours
+      // This controls the update window for scenarios using platform automerge
+      // when renovate loses control over the merge schedule
+      schedule: ["* 9-13 * * 1-5"],
+      /* Maintain backwards compatibility for repositories
             that do not require a merge queue and thus control
             automerges in renovate still */
-            "automergeSchedule": [
-                "* 9-13 * * 1-5"
-            ],
-            "automerge": true,
-            "automergeType": "pr",
-            "automergeStrategy": "auto",
-            // Enable Github automerge (renovate loses control over the merge schedule)
-            "platformAutomerge": true,
-            // Create PRs only if the stability days check has passed
-            // This prevents premature PR merges
-            "prCreation": "not-pending",
-            "internalChecksFilter": "strict",
-            "rebaseWhen": "conflicted"
-        }
-    ]
+      automergeSchedule: ["* 9-13 * * 1-5"],
+      automerge: false,
+      automergeType: "pr",
+      automergeStrategy: "auto",
+      // Enable Github automerge (renovate loses control over the merge schedule)
+      platformAutomerge: false,
+      // Create PRs only if the stability days check has passed
+      // This prevents premature PR merges
+      prCreation: "not-pending",
+      internalChecksFilter: "strict",
+      rebaseWhen: "conflicted",
+    },
+  ],
 }

--- a/renovate-presets/branch-merge.json
+++ b/renovate-presets/branch-merge.json
@@ -1,17 +1,11 @@
 {
-    "timezone": "Europe/Berlin",
-    "packageRules": [
-        {
-            "matchUpdateTypes": [
-                "minor",
-                "patch",
-                "digest"
-            ],
-            "automergeSchedule": [
-                "* 9-13 * * 1-5"
-            ],
-            "automerge": true,
-            "automergeType": "branch"
-        }
-    ]
+  "timezone": "Europe/Berlin",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automergeSchedule": ["* 9-13 * * 1-5"],
+      "automerge": true,
+      "automergeType": "branch"
+    }
+  ]
 }

--- a/renovate-presets/security.json5
+++ b/renovate-presets/security.json5
@@ -1,23 +1,23 @@
 {
-    // Display OSV vulnerability alerts in the dependency dashboard
-    "dependencyDashboardOSVVulnerabilitySummary": "all",
-    // Enable OSV vulnerability alerts for all repositories (experimental feature)
-    "osvVulnerabilityAlerts": true,
-    // Configuration for Security updates
-    "vulnerabilityAlerts": {
-        // no grouping
-        "groupName": null,
-        // may be created at any time
-        "schedule": [],
-        // no dashboard apporval required
-        "dependencyDashboardApproval": false,
-        // specific minimum release age for security updates
-        "minimumReleaseAge": "5 days",
-        // add label indicating sverity of CVEs
-        "addLabels": ["SEVERITY:{{vulnerabilitySeverity}}"],
-        // add commitMessageSuffix indicating sverity of CVEs
-        "commitMessageSuffix": "[SECURITY] [SEVERITY: {{vulnerabilitySeverity}}{{#if (or (equals vulnerabilitySeverity 'MEDIUM') (equals vulnerabilitySeverity 'MODERATE'))}} 🟡{{else if (or (equals vulnerabilitySeverity 'HIGH') (equals vulnerabilitySeverity 'CRITICAL'))}} 🔴{{/if}}]",
-        // use the lowest possible version that fixes the vulnerability
-        "vulnerabilityFixStrategy": "lowest"
-    }
+  // Display OSV vulnerability alerts in the dependency dashboard
+  dependencyDashboardOSVVulnerabilitySummary: "all",
+  // Enable OSV vulnerability alerts for all repositories (experimental feature)
+  osvVulnerabilityAlerts: true,
+  // Configuration for Security updates
+  vulnerabilityAlerts: {
+    // no grouping
+    groupName: null,
+    // may be created at any time
+    schedule: [],
+    // no dashboard apporval required
+    dependencyDashboardApproval: false,
+    // specific minimum release age for security updates
+    minimumReleaseAge: "5 days",
+    // add label indicating sverity of CVEs
+    addLabels: ["SEVERITY:{{vulnerabilitySeverity}}"],
+    // add commitMessageSuffix indicating sverity of CVEs
+    commitMessageSuffix: "[SECURITY] [SEVERITY: {{vulnerabilitySeverity}}{{#if (or (equals vulnerabilitySeverity 'MEDIUM') (equals vulnerabilitySeverity 'MODERATE'))}} 🟡{{else if (or (equals vulnerabilitySeverity 'HIGH') (equals vulnerabilitySeverity 'CRITICAL'))}} 🔴{{/if}}]",
+    // use the lowest possible version that fixes the vulnerability
+    vulnerabilityFixStrategy: "lowest",
+  },
 }


### PR DESCRIPTION
As per the discussion [here](https://leanix.slack.com/archives/C0TALFWA3/p1778055236140559), we want to completely disable renovate for the whole org **temporarily**.

This PR should be reverted after Wed 13 May 2026.

**Key changes**:
- Disabled renovate in `default.json`
- Disable `automerge` and `platformAutomerge` in automerge preset