### PR TITLE
chore: Format all json files to use 2 spaces

### DIFF
--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -6,37 +6,28 @@ Prerequisites for this preset:
  - CI workflow trigger on `merge_group:` event or on push to temporary merge queue branches *(Only if Merge Queue enabled)*
 */
 {
-    "timezone": "Europe/Berlin",
-    "packageRules": [
-        {
-            "matchUpdateTypes": [
-                "minor",
-                "patch",
-                "digest",
-                "lockFileMaintenance"
-            ],
-            // Create PRs only during working hours
-            // This controls the update window for scenarios using platform automerge
-            // when renovate loses control over the merge schedule
-            "schedule": [
-                "* 9-13 * * 1-5"
-            ],
-            /* Maintain backwards compatibility for repositories
+  timezone: "Europe/Berlin",
+  packageRules: [
+    {
+      matchUpdateTypes: ["minor", "patch", "digest", "lockFileMaintenance"],
+      // Create PRs only during working hours
+      // This controls the update window for scenarios using platform automerge
+      // when renovate loses control over the merge schedule
+      schedule: ["* 9-13 * * 1-5"],
+      /* Maintain backwards compatibility for repositories
             that do not require a merge queue and thus control
             automerges in renovate still */
-            "automergeSchedule": [
-                "* 9-13 * * 1-5"
-            ],
-            "automerge": true,
-            "automergeType": "pr",
-            "automergeStrategy": "auto",
-            // Enable Github automerge (renovate loses control over the merge schedule)
-            "platformAutomerge": true,
-            // Create PRs only if the stability days check has passed
-            // This prevents premature PR merges
-            "prCreation": "not-pending",
-            "internalChecksFilter": "strict",
-            "rebaseWhen": "conflicted"
-        }
-    ]
+      automergeSchedule: ["* 9-13 * * 1-5"],
+      automerge: true,
+      automergeType: "pr",
+      automergeStrategy: "auto",
+      // Enable Github automerge (renovate loses control over the merge schedule)
+      platformAutomerge: true,
+      // Create PRs only if the stability days check has passed
+      // This prevents premature PR merges
+      prCreation: "not-pending",
+      internalChecksFilter: "strict",
+      rebaseWhen: "conflicted",
+    },
+  ],
 }

--- a/renovate-presets/branch-merge.json
+++ b/renovate-presets/branch-merge.json
@@ -1,17 +1,11 @@
 {
-    "timezone": "Europe/Berlin",
-    "packageRules": [
-        {
-            "matchUpdateTypes": [
-                "minor",
-                "patch",
-                "digest"
-            ],
-            "automergeSchedule": [
-                "* 9-13 * * 1-5"
-            ],
-            "automerge": true,
-            "automergeType": "branch"
-        }
-    ]
+  "timezone": "Europe/Berlin",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automergeSchedule": ["* 9-13 * * 1-5"],
+      "automerge": true,
+      "automergeType": "branch"
+    }
+  ]
 }

--- a/renovate-presets/security.json5
+++ b/renovate-presets/security.json5
@@ -1,23 +1,23 @@
 {
-    // Display OSV vulnerability alerts in the dependency dashboard
-    "dependencyDashboardOSVVulnerabilitySummary": "all",
-    // Enable OSV vulnerability alerts for all repositories (experimental feature)
-    "osvVulnerabilityAlerts": true,
-    // Configuration for Security updates
-    "vulnerabilityAlerts": {
-        // no grouping
-        "groupName": null,
-        // may be created at any time
-        "schedule": [],
-        // no dashboard apporval required
-        "dependencyDashboardApproval": false,
-        // specific minimum release age for security updates
-        "minimumReleaseAge": "5 days",
-        // add label indicating sverity of CVEs
-        "addLabels": ["SEVERITY:{{vulnerabilitySeverity}}"],
-        // add commitMessageSuffix indicating sverity of CVEs
-        "commitMessageSuffix": "[SECURITY] [SEVERITY: {{vulnerabilitySeverity}}{{#if (or (equals vulnerabilitySeverity 'MEDIUM') (equals vulnerabilitySeverity 'MODERATE'))}} 🟡{{else if (or (equals vulnerabilitySeverity 'HIGH') (equals vulnerabilitySeverity 'CRITICAL'))}} 🔴{{/if}}]",
-        // use the lowest possible version that fixes the vulnerability
-        "vulnerabilityFixStrategy": "lowest"
-    }
+  // Display OSV vulnerability alerts in the dependency dashboard
+  dependencyDashboardOSVVulnerabilitySummary: "all",
+  // Enable OSV vulnerability alerts for all repositories (experimental feature)
+  osvVulnerabilityAlerts: true,
+  // Configuration for Security updates
+  vulnerabilityAlerts: {
+    // no grouping
+    groupName: null,
+    // may be created at any time
+    schedule: [],
+    // no dashboard apporval required
+    dependencyDashboardApproval: false,
+    // specific minimum release age for security updates
+    minimumReleaseAge: "5 days",
+    // add label indicating sverity of CVEs
+    addLabels: ["SEVERITY:{{vulnerabilitySeverity}}"],
+    // add commitMessageSuffix indicating sverity of CVEs
+    commitMessageSuffix: "[SECURITY] [SEVERITY: {{vulnerabilitySeverity}}{{#if (or (equals vulnerabilitySeverity 'MEDIUM') (equals vulnerabilitySeverity 'MODERATE'))}} 🟡{{else if (or (equals vulnerabilitySeverity 'HIGH') (equals vulnerabilitySeverity 'CRITICAL'))}} 🔴{{/if}}]",
+    // use the lowest possible version that fixes the vulnerability
+    vulnerabilityFixStrategy: "lowest",
+  },
 }

--- a/renovate-presets/security.json5
+++ b/renovate-presets/security.json5
@@ -9,13 +9,13 @@
     groupName: null,
     // may be created at any time
     schedule: [],
-    // no dashboard apporval required
+    // no dashboard approval required
     dependencyDashboardApproval: false,
     // specific minimum release age for security updates
     minimumReleaseAge: "5 days",
-    // add label indicating sverity of CVEs
+    // add label indicating severity of CVEs
     addLabels: ["SEVERITY:{{vulnerabilitySeverity}}"],
-    // add commitMessageSuffix indicating sverity of CVEs
+    // add commitMessageSuffix indicating severity of CVEs
     commitMessageSuffix: "[SECURITY] [SEVERITY: {{vulnerabilitySeverity}}{{#if (or (equals vulnerabilitySeverity 'MEDIUM') (equals vulnerabilitySeverity 'MODERATE'))}} 🟡{{else if (or (equals vulnerabilitySeverity 'HIGH') (equals vulnerabilitySeverity 'CRITICAL'))}} 🔴{{/if}}]",
     // use the lowest possible version that fixes the vulnerability
     vulnerabilityFixStrategy: "lowest",


### PR DESCRIPTION
# Reformat Renovate Preset JSON Files to Use 2-Space Indentation

### Chore

🔧 Reformatted all Renovate preset JSON/JSON5 configuration files to use consistent 2-space indentation instead of 4-space indentation. No functional changes were made.

### Changes

* `renovate-presets/automerge.json5`: Reformatted from 4-space to 2-space indentation; condensed single-element arrays to inline format (e.g., `"schedule"` and `"automergeSchedule"`).
* `renovate-presets/branch-merge.json`: Reformatted from 4-space to 2-space indentation; condensed `matchUpdateTypes` and `automergeSchedule` arrays to inline format.
* `renovate-presets/security.json5`: Reformatted from 4-space to 2-space indentation; all keys and values remain unchanged.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.43`

- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `85beaee1-cf2b-49fe-bc0e-0decf122b46e`
- File Content Strategy: Full file content
</details>
