### PR TITLE
Temporarily disable renovate completely for sapphire week

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,5 +1,5 @@
 {
-  "enabled": true,
+  "enabled": false,
   "extends": [
     "config:best-practices",
     ":pinAllExceptPeerDependencies",

--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -18,11 +18,11 @@ Prerequisites for this preset:
             that do not require a merge queue and thus control
             automerges in renovate still */
       automergeSchedule: ["* 9-13 * * 1-5"],
-      automerge: true,
+      automerge: false,
       automergeType: "pr",
       automergeStrategy: "auto",
       // Enable Github automerge (renovate loses control over the merge schedule)
-      platformAutomerge: true,
+      platformAutomerge: false,
       // Create PRs only if the stability days check has passed
       // This prevents premature PR merges
       prCreation: "not-pending",


### PR DESCRIPTION
As per the discussion [here](https://leanix.slack.com/archives/C0TALFWA3/p1778055236140559), we want to completely disable renovate for the whole org **temporarily**.

This PR should be reverted on or after Thu 14 May 2026.

**Key changes**:
- Disabled renovate in `default.json`
- Disable `automerge` and `platformAutomerge` in automerge preset