### PR TITLE
fix: 5d minimumReleaseAge for npm updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,9 +6,6 @@
     "github>leanix/.github//renovate-presets/security.json5"
   ],
   "rebaseWhen": "conflicted",
-  "internalChecksFilter": "strict",
-  "minimumReleaseAge": "5 days",
-  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "reviewersFromCodeOwners": true,
   "packageRules": [
     {

--- a/renovate-presets/security.json5
+++ b/renovate-presets/security.json5
@@ -4,6 +4,23 @@
   // Enable OSV vulnerability alerts for all repositories (experimental feature)
   osvVulnerabilityAlerts: true,
   // Configuration for Security updates
+
+  // Define minimumReleaseAge, to reduce the risk of supplyChain attacks
+  internalChecksFilter: "strict",
+  minimumReleaseAge: "5 days",
+  minimumReleaseAgeBehaviour: "timestamp-optional",
+  packageRules: [
+    // Override minimumReleaseAge configured in packageRule in security:minimumReleaseAgeNpm
+    // preset that is more specific and overrides the global definition above
+    {
+      "internalChecksFilter": "strict",
+      "matchDatasources": [
+        "npm"
+      ],
+      "minimumReleaseAge": "5 days"
+    },
+  ],
+
   vulnerabilityAlerts: {
     // no grouping
     groupName: null,


### PR DESCRIPTION
**WHY** The definition for minimumReleaseAge in the security:minimumReleaseAgeNpm preset overrode the global definition leading to unexpected behavior.

**WHAT** Define a packageRule overriding definitions in security:minimumReleaseAgeNpm preset