### PR TITLE
Temporarily disable auto and branch merge for Sapphire Madrid

### DIFF
--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -18,11 +18,11 @@ Prerequisites for this preset:
             that do not require a merge queue and thus control
             automerges in renovate still */
       automergeSchedule: ["* 9-13 * * 1-5"],
-      automerge: true,
+      automerge: false,
       automergeType: "pr",
       automergeStrategy: "auto",
       // Enable Github automerge (renovate loses control over the merge schedule)
-      platformAutomerge: true,
+      platformAutomerge: false,
       // Create PRs only if the stability days check has passed
       // This prevents premature PR merges
       prCreation: "not-pending",

--- a/renovate-presets/branch-merge.json
+++ b/renovate-presets/branch-merge.json
@@ -4,7 +4,7 @@
     {
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automergeSchedule": ["* 9-13 * * 1-5"],
-      "automerge": true,
+      "automerge": false,
       "automergeType": "branch"
     }
   ]


### PR DESCRIPTION
# Temporarily Disable Auto and Branch Merge for Sapphire Madrid

## Context
https://leanix.slack.com/archives/C0TALFWA3/p1779092291921419

### Chore

🔧 Temporarily disabling automerge and platform automerge settings across the Renovate preset configurations to prevent automated merges during the Sapphire Madrid period.

### Changes

* `renovate-presets/automerge.json5`: Set `automerge` to `false` and `platformAutomerge` to `false`, disabling both Renovate-controlled and GitHub platform automerge for minor, patch, digest, and lock file maintenance updates.
* `renovate-presets/branch-merge.json`: Set `automerge` to `false`, disabling branch-type automerge for minor, patch, and digest updates.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `bee6b0be-4c89-4267-a08f-ee09ecdd6993`
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
