### PR TITLE
Revert "Temporarily disable auto and branch merge for Sapphire Madrid"

### DIFF
--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -18,11 +18,11 @@ Prerequisites for this preset:
             that do not require a merge queue and thus control
             automerges in renovate still */
       automergeSchedule: ["* 9-13 * * 1-5"],
-      automerge: false,
+      automerge: true,
       automergeType: "pr",
       automergeStrategy: "auto",
       // Enable Github automerge (renovate loses control over the merge schedule)
-      platformAutomerge: false,
+      platformAutomerge: true,
       // Create PRs only if the stability days check has passed
       // This prevents premature PR merges
       prCreation: "not-pending",

--- a/renovate-presets/branch-merge.json
+++ b/renovate-presets/branch-merge.json
@@ -4,7 +4,7 @@
     {
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automergeSchedule": ["* 9-13 * * 1-5"],
-      "automerge": false,
+      "automerge": true,
       "automergeType": "branch"
     }
   ]


### PR DESCRIPTION
Reverts leanix/.github#95

To be merged **on or after Friday 22 May 2026** 