### PR TITLE
chore: no `minimumReleaseAge` for leanix internal dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,11 +18,6 @@
       "allowedVersions": "<5.0"
     },
     {
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["@leanix/*"],
-      "minimumReleaseAge": null
-    },
-    {
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["gradle/*"],
       "allowedVersions": "<6"

--- a/renovate-presets/security.json5
+++ b/renovate-presets/security.json5
@@ -19,6 +19,16 @@
       ],
       "minimumReleaseAge": "5 days"
     },
+    {
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@leanix/*"],
+      "minimumReleaseAge": null
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["leanix/*"],
+      "minimumReleaseAge": null
+    },
   ],
 
   vulnerabilityAlerts: {


### PR DESCRIPTION
**WHY** Increase the rollout speed for internal changes. Internal dependencies are considered safe.

**WHAT**
- add github actions
- move all packageRules controling `minimumReleaseAge` to security preset