### PR TITLE
DEVX-773: (AI GENERATED) add explicit permissions to workflow jobs

### DIFF
--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -9,6 +9,8 @@ jobs:
   detect-modified-renovate-configs:
     name: Detect modified Renovate configuration files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.changed-renovate-configs.outputs.all_changed_files }}
     steps:
@@ -27,6 +29,8 @@ jobs:
   validate-renovate-configs:
     name: Validate Renovate Configs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [detect-modified-renovate-configs]
     if: ${{ needs.detect-modified-renovate-configs.outputs.matrix != '[]' }}
     strategy:
@@ -51,10 +55,11 @@ jobs:
   collect-validation-results:
     # This job must always run and report a status since it is a required status check
     name: Renovate validation results collector
-    needs: 
+    needs:
         - detect-modified-renovate-configs
         - validate-renovate-configs
     runs-on: ubuntu-latest
+    permissions: {}
     if: always() && !cancelled()
     steps:
       - name: All renovate config validation jobs passed


### PR DESCRIPTION
Adds minimal required `permissions:` blocks to workflow jobs that were missing them.

**Motivation:** Explicit permissions follow the principle of least privilege and prevent accidental access escalation.

**Note:** Please review this PR carefully, as it was generated with assistance from AI. This is only a migration helper, so ensure you thoroughly evaluate the changes before **MERGING IT ON YOUR OWN**.

**Timeline:**
   _From June 1_
   Default switches to read-only org-wide. Repos can still override the setting for their own workflows — giving teams a grace week to finish up.
   _From June 8_
   Read-only is enforced via org policy. No more per-repo override.

**Changes:**
- `validate-renovate-config.yml`: jobs `detect-modified-renovate-configs`, `validate-renovate-configs`, `collect-validation-results`

**Permissions added:**
- `detect-modified-renovate-configs`: `contents: read` (uses actions/checkout)
- `validate-renovate-configs`: `contents: read` (uses actions/checkout)
- `collect-validation-results`: `permissions: {}` (no rules matched)