### PR TITLE
chore(renovate-preset): enable automerge for security updates

### DIFF
--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -24,8 +24,8 @@ Prerequisites for this preset:
       // Enable Github automerge (renovate loses control over the merge schedule)
       platformAutomerge: false,
       // Create PRs only if the stability days check has passed
-      // This prevents premature PR merges
       prCreation: "not-pending",
+      // This prevents premature PR merges
       internalChecksFilter: "strict",
       rebaseWhen: "conflicted",
     },

--- a/renovate-presets/security.json5
+++ b/renovate-presets/security.json5
@@ -22,6 +22,14 @@
   ],
 
   vulnerabilityAlerts: {
+    // enable automerging of security updates to reduce the time to fix vulnerabilities
+    automerge: true,
+    // Enable Github automerge
+    platformAutomerge: true,
+    // Create PRs only if the stability days check has passed
+    prCreation: "not-pending",
+    // This prevents premature PR merges
+    internalChecksFilter: "strict",
     // no grouping
     groupName: null,
     // may be created at any time


### PR DESCRIPTION
**WHY** Reduce time to fix for security updates