### PR TITLE
feat(templates): add template for npm test-release-report CI workflow

### DIFF
--- a/workflow-templates/ci.npm.properties.json
+++ b/workflow-templates/ci.npm.properties.json
@@ -1,0 +1,13 @@
+{
+    "name": "npm CI (test-release-report)",
+    "description": "Standard CI workflow for npm projects released as Docker images.",
+    "iconName": "check-circle-fill",
+    "categories": [
+        "JavaScript",
+        "TypeScript"
+    ],
+    "filePatterns": [
+        "package.json$",
+        ".nvmrc$"
+    ]
+}

--- a/workflow-templates/ci.npm.yml
+++ b/workflow-templates/ci.npm.yml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  push:
+    branches:
+      - $default_branch
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+
+env:
+  ACTION_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+jobs:
+  ci:
+    if: ${{ !github.event.pull_request.draft }}
+    permissions:
+      contents: write
+      actions: write
+      packages: read
+    uses: leanix/shared-github-workflows/.github/workflows/test-release-report.npm.reusable.yml@e1282e41e08bf67c4e6835c20c07c85e3254f5ae
+    secrets: inherit
+    with:
+      node-version-file: ".nvmrc"


### PR DESCRIPTION
# Add GitHub Actions Workflow Template for npm CI (test-release-report)

### New Feature

✨ Introduces a new GitHub Actions workflow template for npm projects that use the `test-release-report` CI pattern. This template provides a standardized CI setup for JavaScript/TypeScript projects released as Docker images.

### Changes

* `workflow-templates/ci.npm.properties.json`: Adds metadata for the workflow template, including its name, description, icon, categories (`JavaScript`, `TypeScript`), and file pattern triggers (`package.json`, `.nvmrc`).
* `workflow-templates/ci.npm.yml`: Defines the CI workflow that triggers on pushes to the default branch and on pull request events (opened, ready for review, reopened, synchronize). It skips draft PRs and delegates execution to the reusable `test-release-report.npm.reusable.yml` workflow from the `leanix/shared-github-workflows` repository, passing `.nvmrc` as the Node.js version file.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.0`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `502db930-842b-11f1-8061-2cad7d5000b0`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
