### PR TITLE
ECO-2024 Set prHourlyLimit to 10 in default config

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
     ":pinAllExceptPeerDependencies",
     "github>leanix/.github//renovate-presets/security.json5"
   ],
+  "prHourlyLimit": 10,
   "rebaseWhen": "conflicted",
   "reviewersFromCodeOwners": true,
   "packageRules": [

--- a/default.json
+++ b/default.json
@@ -5,7 +5,7 @@
     ":pinAllExceptPeerDependencies",
     "github>leanix/.github//renovate-presets/security.json5"
   ],
-  "prHourlyLimit": 10,
+  "prHourlyLimit": 5,
   "rebaseWhen": "conflicted",
   "reviewersFromCodeOwners": true,
   "packageRules": [


### PR DESCRIPTION
## Summary
- Adds `prHourlyLimit: 10` to `default.json` so all repositories consuming the shared Renovate config benefit from a rate limit of 10 PRs per hour

## Test plan
- [ ] Verify Renovate picks up the new setting from the shared config in consuming repositories