### PR TITLE
ECO-2024 Increase Renovate limits and extend automerge schedule

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,7 +5,7 @@
     ":pinAllExceptPeerDependencies",
     "github>leanix/.github//renovate-presets/security.json5"
   ],
-  "prHourlyLimit": 5,
+  "prHourlyLimit": 10,
   "rebaseWhen": "conflicted",
   "reviewersFromCodeOwners": true,
   "packageRules": [

--- a/renovate-presets/automerge.json5
+++ b/renovate-presets/automerge.json5
@@ -13,11 +13,11 @@ Prerequisites for this preset:
       // Create PRs only during working hours
       // This controls the update window for scenarios using platform automerge
       // when renovate loses control over the merge schedule
-      schedule: ["* 9-13 * * 1-5"],
+      schedule: ["* 9-15 * * 1-5"],
       /* Maintain backwards compatibility for repositories
             that do not require a merge queue and thus control
             automerges in renovate still */
-      automergeSchedule: ["* 9-13 * * 1-5"],
+      automergeSchedule: ["* 9-15 * * 1-5"],
       automerge: true,
       automergeType: "pr",
       automergeStrategy: "auto",


### PR DESCRIPTION
## Summary

- Increase `prHourlyLimit` from 5 to 10 in `default.json`
- Extend automerge schedule from 1pm to 3pm (`9-13` → `9-15`) in `renovate-presets/automerge.json5`

## Test plan

- [ ] Verify Renovate config is valid (CI)
- [ ] Confirm automerge window is 9:00–15:00 Europe/Berlin on weekdays