### PR TITLE
feat(renovate): use artifactory for maven deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -28,6 +28,15 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["axios"],
       "allowedVersions": "!/(1\\.14\\.1)|(0\\.30\\.4)/"
+    },
+    {
+      "matchDatasources": [
+        "maven"
+      ],
+      "registryUrls": [
+        "https://common.repositories.cloud.sap/artifactory/maven-central",
+        "https://repo1.maven.org/maven2"
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Configure Artifactory as Maven Dependency Registry in Renovate

### New Feature

✨ Added a Renovate configuration rule to route Maven dependency lookups through SAP's Artifactory instance (`common.repositories.cloud.sap`) as the primary registry, with Maven Central as a fallback.

### Changes

* `default.json`: Added a new `packageRules` entry that sets `registryUrls` for all `maven` datasources, prioritizing the internal Artifactory Maven Central mirror before falling back to the official Maven Central repository.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `32d6caa0-97dd-11f1-824f-b037994588ea`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
